### PR TITLE
View controller

### DIFF
--- a/src/main/java/com/softwaredesign/project/RestaurantDriver.java
+++ b/src/main/java/com/softwaredesign/project/RestaurantDriver.java
@@ -460,46 +460,16 @@ public class RestaurantDriver {
     /**
      * Completely restarts the application by resetting all components and reinitializing
      */
-    public synchronized void restart() {
-        System.out.println("[RestaurantDriver] Performing full application restart");
-        
-        // Stop the game engine before restarting
-        gameEngine.stop();
-        
-        // Stop any ongoing operations
-        try {
-            // Reset all entity references
-            this.waiters = null;
-            this.chefs = null;
-            this.kitchen = null;
-            this.menu = null;
-            this.orderManager = null;
-            this.tables = null;
-            this.inventory = null;
-            this.seatingPlan = null;
-            
-            // Reset controllers
-            this.diningRoomController = null;
-            this.kitchenController = null;
-            this.inventoryController = null;
-            
-            // Reset configuration controller but keep the mediator
-            this.configController = null;
-            
-            // Reinitialize configuration
-            initializeConfiguration();
-            
-            // Tell the application to show the welcome view
-            // Use SwingUtilities.invokeLater to ensure UI updates happen on the EDT
-            javax.swing.SwingUtilities.invokeLater(() -> {
-                app.showView(ViewType.WELCOME);
-            });
-            
-            System.out.println("[RestaurantDriver] Application restart complete");
-        } catch (Exception e) {
-            System.err.println("[RestaurantDriver] Error during restart: " + e.getMessage());
-            e.printStackTrace();
+    public synchronized void restartGame() {
+        System.out.println("[RestaurantDriver] Restarting game...");
+        if (gameEngine != null) {
+            gameEngine.stop();
         }
+        // Delete the current RestaurantApplication instance
+        this.app = null;
+        // Create a new RestaurantDriver to reinitialize all components
+        RestaurantDriver newDriver = new RestaurantDriver();
+        newDriver.start();
     }
 
     private void setupDemoScenario() {

--- a/src/main/java/com/softwaredesign/project/view/DiningConfigurationView.java
+++ b/src/main/java/com/softwaredesign/project/view/DiningConfigurationView.java
@@ -255,6 +255,10 @@ public class DiningConfigurationView extends ConfigurationView {
             });
             
             maxCapacityLabel = window.addLabel("(Maximum " + maxCapacity + " seats per table)", 40, 22);
+            
+            // Update labels to show current values
+            updateTableCountLabel();
+            updateTableCapacityLabel();
         } catch (Exception e) {
             System.err.println("[DiningConfigurationView] Error creating table configuration: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/com/softwaredesign/project/view/DiningConfigurationView.java
+++ b/src/main/java/com/softwaredesign/project/view/DiningConfigurationView.java
@@ -16,9 +16,9 @@ public class DiningConfigurationView extends ConfigurationView {
     private TLabel maxTablesLabel;
     private TLabel maxCapacityLabel; 
     private int maxTables;
-    private int currentTableCount;
+    private int currentTableCount = 1;
     private int maxCapacity;
-    private int currentTableCapacity;
+    private int currentTableCapacity = 1;
     private int minWaiters;
     private int maxWaiters; 
     private int maxSpeed = 5; // Default value
@@ -208,7 +208,7 @@ public class DiningConfigurationView extends ConfigurationView {
         try {
             // Table count configuration
             window.addLabel("Number of Tables:", 2, 20);
-            tableCountLabel = window.addLabel("0", 25, 20);
+            tableCountLabel = window.addLabel(String.valueOf(currentTableCount), 25, 20);
             
             // Add buttons to increase/decrease table count
             window.addButton("-", 30, 20, new TAction() {
@@ -233,7 +233,7 @@ public class DiningConfigurationView extends ConfigurationView {
             
             // Table capacity configuration
             window.addLabel("Table Capacity:", 2, 22);
-            tableCapacityLabel = window.addLabel("0", 25, 22);
+            tableCapacityLabel = window.addLabel(String.valueOf(currentTableCapacity), 25, 22);
             
             // Add buttons to increase/decrease table capacity
             window.addButton("-", 30, 22, new TAction() {

--- a/src/main/java/com/softwaredesign/project/view/RestaurantApplication.java
+++ b/src/main/java/com/softwaredesign/project/view/RestaurantApplication.java
@@ -140,48 +140,20 @@ public class RestaurantApplication extends TApplication {
     }
 
     /**
-     * Properly restarts the application by reinitializing all views and resetting the application state.
+     * Properly restarts the application by calling exit() and reinitializing through the driver.
      */
     private void restartApplication() {
         System.out.println("[RestaurantApplication] Restarting application");
-        try {
-            // Use SwingUtilities.invokeLater to ensure UI updates happen on the EDT
-            javax.swing.SwingUtilities.invokeLater(() -> {
-                try {
-                    // Clear the current view
-                    currentView = null;
-                    
-                    // Clear all widgets from the main window
-                    List<TWidget> widgetsToRemove = new ArrayList<>(mainWindow.getChildren());
-                    for (TWidget widget : widgetsToRemove) {
-                        mainWindow.remove(widget);
-                    }
-                    
-                    // Reset the mediator
-                    RestaurantViewMediator mediator = RestaurantViewMediator.getInstance();
-                    mediator.reset();
-                    
-                    // Reinitialize all views
-                    views.clear();
-                    initializeViews();
-                    
-                    // If driver is available, use it for a complete restart
-                    if (driver != null) {
-                        driver.restart();
-                    } else {
-                        // Fallback to just showing welcome view
-                        showView(ViewType.WELCOME);
-                    }
-                    
-                    System.out.println("[RestaurantApplication] Application restart completed");
-                } catch (Exception e) {
-                    System.err.println("[RestaurantApplication] ERROR during restart: " + e.getMessage());
-                    e.printStackTrace();
-                }
-            });
-        } catch (Exception e) {
-            System.err.println("[RestaurantApplication] ERROR during restart: " + e.getMessage());
-            e.printStackTrace();
+        // Reset the mediator to clear any cached configuration state (including min/max number of chefs)
+        RestaurantViewMediator.getInstance().reset();
+        // Exit the current application instance.
+        this.exit();
+        // Call the driver's restartGame() method to reinitialize everything
+        if (driver != null) {
+        driver.restartGame();
+        } else {
+        // Fallback to just showing the welcome view if no driver is available
+            showView(ViewType.WELCOME);
         }
     }
 


### PR DESCRIPTION
- Couple teeny bugs around ui where the set number of tables and seats wasn't persisiting if you went out of and back into that configuration window. 

-  Fixed the restart functionality for 🤞hopefully🤞the last time. Now restart kills current app and launches a new one. 
    -  This means the window closes and another one opens, which is not ideal. 
    - However, it avoids all of the messiness of clearing fields in configcontroller and each view, recreating order manager, stationmanager etc. 
    - Previously, this was causing a lot of errors with some things either being deleted or lingering data between resets, was confusing and kept breaking with changes to the configuraiton or backend logic
    - For the excersise at hand and the time we have left, I think this is a suitable design decision.